### PR TITLE
Fixing the broken Docker Tutorial link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This guide was tested on Ubuntu 22.04 host.
 
 #### Install docker
 
--   Follow this [tutorial](/https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-22-04) to install and setup docker on your system.
+-   Follow this [tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-22-04) to install and setup docker on your system.
 
 -   Support to run arm64 docker containers on the host:
 


### PR DESCRIPTION
Fixing the broken Docker Tutorial link in README.md